### PR TITLE
Disk should returns the size of the disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ yields (without logging output):
       	  ],
       	  "cpu": "12",
       	  "memory": "98304",
-      	  "disk": "7",
+      	  "disk": "500",
       	  "arch": "x86_64"
     	},
     	{
@@ -41,7 +41,7 @@ yields (without logging output):
       	  ],
       	  "cpu": "16",
       	  "memory": "131072",
-      	  "disk": "0",
+      	  "disk": "500",
       	  "arch": "x86_64"
     	},
         {
@@ -59,7 +59,7 @@ yields (without logging output):
       	  ],
       	  "cpu": "20",
       	  "memory": "98304",
-      	  "disk": "1",
+      	  "disk": "1200",
       	  "arch": "x86_64"
         }
       ]


### PR DESCRIPTION
Disk key should give the size of the first disk in GB, not the number of hard
drive. During the nova boot, nova will compare this value with the
minimal mandatory size associated with the Glance image.

Without this patch, nova will always fail and returns the "no valid host was found"
message as soon as the size is greater than 1.
